### PR TITLE
Fix for issue #7 ( Blank page on Safari )

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/.DS_Store": true,
+    "target/": true,
+    "bin/": true,
+    "node_modules/": true
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.1.0",
+    "command": "mvn",
+    "isShellCommand": true,
+    "showOutput": "always",
+    "suppressTaskName": true,
+    "tasks": [
+      {
+          "taskName": "build",
+          "args": ["package"]
+      },
+      {
+        "taskName": "clean",
+        "args": ["clean"]
+
+      }
+    ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,18 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>2.10</version>
+                <executions>
+                    <execution>
+                        <id>build-classpath</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputFile>classpath.txt</outputFile>
+                </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/resources/app/assets/js/app.js
+++ b/src/main/resources/app/assets/js/app.js
@@ -6,8 +6,26 @@ angular.module('budgetApp').constant('angularMomentConfig', {
 });
 
 angular.module('budgetApp').constant('appConfig', {
-  version: '1.0.4'
+  version: '1.0.4',
+  analyticsAccount: 'UA-53663138-1'
 });
+
+function configureAnalytics(AnalyticsProvider, analyticsAccount) {
+      // initial configuration
+      AnalyticsProvider.setAccount(analyticsAccount);
+
+      // track all routes (or not)
+      AnalyticsProvider.trackPages(true);
+
+      //Optional set domain (Use 'none' for testing on localhost)
+      //        AnalyticsProvider.setDomainName('none');
+
+      // Use analytics.js instead of ga.js
+      AnalyticsProvider.useAnalytics(true);
+
+      // change page event name
+      AnalyticsProvider.setPageEvent('$routeChangeStart');
+}
 
 budgetApp.config(['$routeProvider', '$httpProvider', '$locationProvider', '$injector', 'appConfig',
       function($routeProvider, $httpProvider, $locationProvider, $injector, appConfig) {
@@ -17,20 +35,7 @@ budgetApp.config(['$routeProvider', '$httpProvider', '$locationProvider', '$inje
           AnalyticsProvider = $injector.get('angular-google-analytics');
 
           // have google analytics
-          // initial configuration
-          AnalyticsProvider.setAccount('UA-53663138-1');
-
-          // track all routes (or not)
-          AnalyticsProvider.trackPages(true);
-
-          //Optional set domain (Use 'none' for testing on localhost)
-          //        AnalyticsProvider.setDomainName('none');
-
-          // Use analytics.js instead of ga.js
-          AnalyticsProvider.useAnalytics(true);
-
-          // change page event name
-          AnalyticsProvider.setPageEvent('$routeChangeStart');
+          configureAnalytics(AnalyticsProvider, appConfig.analyticsAccount);
         } catch(e) {
             // no analytics, no sweat
           console.log("No Google Analytics available. Ignoring.");

--- a/src/main/resources/app/assets/js/app.js
+++ b/src/main/resources/app/assets/js/app.js
@@ -1,5 +1,5 @@
 
-var budgetApp = angular.module('budgetApp', ['ngRoute', 'ngAnimate', 'wu.masonry', 'ui.bootstrap', 'angular-google-analytics', 'angular-loading-bar', 'angularMoment', 'financeControllers', 'financeServices']);
+var budgetApp = angular.module('budgetApp', ['ngRoute', 'ngAnimate', 'wu.masonry', 'ui.bootstrap', 'angular-loading-bar', 'angularMoment', 'financeControllers', 'financeServices']);
 
 angular.module('budgetApp').constant('angularMomentConfig', {
   timezone: 'utc'
@@ -9,24 +9,32 @@ angular.module('budgetApp').constant('appConfig', {
   version: '1.0.4'
 });
 
-budgetApp.config(['$routeProvider', '$httpProvider', '$locationProvider', 'AnalyticsProvider', 'appConfig',
-      function($routeProvider, $httpProvider, $locationProvider, AnalyticsProvider, appConfig) {
+budgetApp.config(['$routeProvider', '$httpProvider', '$locationProvider', '$injector', 'appConfig',
+      function($routeProvider, $httpProvider, $locationProvider, $injector, appConfig) {
         $httpProvider.interceptors.push('TokenInterceptor');
 
-        // initial configuration
-        AnalyticsProvider.setAccount('UA-53663138-1');
+        try {
+          AnalyticsProvider = $injector.get('angular-google-analytics');
 
-        // track all routes (or not)
-        AnalyticsProvider.trackPages(true);
+          // have google analytics
+          // initial configuration
+          AnalyticsProvider.setAccount('UA-53663138-1');
 
-        //Optional set domain (Use 'none' for testing on localhost)
-//        AnalyticsProvider.setDomainName('none');
+          // track all routes (or not)
+          AnalyticsProvider.trackPages(true);
 
-        // Use analytics.js instead of ga.js
-        AnalyticsProvider.useAnalytics(true);
+          //Optional set domain (Use 'none' for testing on localhost)
+          //        AnalyticsProvider.setDomainName('none');
 
-        // change page event name
-        AnalyticsProvider.setPageEvent('$routeChangeStart');
+          // Use analytics.js instead of ga.js
+          AnalyticsProvider.useAnalytics(true);
+
+          // change page event name
+          AnalyticsProvider.setPageEvent('$routeChangeStart');
+        } catch(e) {
+            // no analytics, no sweat
+          console.log("No Google Analytics available. Ignoring.");
+        }
 
         $locationProvider.html5Mode({
           enabled: true,
@@ -108,7 +116,7 @@ budgetApp.config(['$routeProvider', '$httpProvider', '$locationProvider', 'Analy
       }]
 );
 
-budgetApp.run(function($rootScope, $location, $window, Analytics, AuthenticationService, UserService) {
+budgetApp.run(function($rootScope, $location, $window, AuthenticationService, UserService) {
   $rootScope.$on("$routeChangeStart", function(event, nextRoute, currentRoute) {
 
     if(!$rootScope.user && AuthenticationService.anonymous.indexOf(nextRoute.originalPath) == -1) {

--- a/src/main/resources/app/index.html
+++ b/src/main/resources/app/index.html
@@ -3,20 +3,31 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>Budget App</title>
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
-  <link href="https://cdn.jsdelivr.net/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://cdn.jsdelivr.net/fontawesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" />
+  <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">
+  <link href="//cdn.jsdelivr.net/bootstrap/3.3/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="//cdn.jsdelivr.net/fontawesome/4.6/css/font-awesome.min.css" rel="stylesheet" />
   <!--TODO move to jsdeliv-->
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/1.5.2/css/ionicons.min.css" rel="stylesheet" />
-  <link href="https://cdn.jsdelivr.net/jquery.footable/2.0.3/css/footable.core.min.css" rel="stylesheet" />
+  <link href="/app/assets/css/ionicons.min.css" rel="stylesheet" />
+  <link href="/app/assets/css/footable.core.min.css" rel="stylesheet" />
   <link href="/app/assets/css/loading-bar.css" rel="stylesheet" />
   <link href="/app/assets/css/style.css" rel="stylesheet" />
 
-  <script src="https://cdn.jsdelivr.net/g/jquery@2.1.1,angularjs@1.4.2(angular.min.js+angular-resource.min.js+angular-route.min.js+angular-cookies.min.js+angular-animate.min.js),momentjs@2.10.6,lodash@3.10.1,angular.bootstrap@0.13.3(ui-bootstrap-tpls.min.js),angular.moment@0.10.2,jquery.footable@2.0.3(footable.min.js+footable.sort.min.js+footable.paginate.min.js),jquery.flot@0.8.3(jquery.flot.min.js+jquery.flot.time.min.js+jquery.flot.categories.min.js+jquery.flot.pie.min.js+jquery.flot.resize.min.js),masonry@3.3.1"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-loading-bar/0.8.0/loading-bar.min.js"></script>
+  <script src="//cdn.jsdelivr.net/g/jquery@2.1"></script>
+  <!--<script src="//cdn.jsdelivr.net/g/angularjs@1.5(angular.min.js+angular-cookies.min.js+angular-resource.min.js+angular-route.min.js+angular-animate.min.js)"></script>-->
+  <script src="//cdn.jsdelivr.net/g/angularjs@1.4(angular.js+angular-cookies.js+angular-resource.js+angular-route.js+angular-animate.js)"></script>
+  <script src="//cdn.jsdelivr.net/g/angular.bootstrap@2.1(ui-bootstrap-tpls.min.js)"></script>
+  <script src="//cdn.jsdelivr.net/g/jquery.flot@0.8(jquery.flot.min.js+jquery.flot.categories.min.js+jquery.flot.time.js+jquery.flot.resize.js+jquery.flot.pie.js)"></script>
+  <script src="//cdn.jsdelivr.net/g/jquery.footable@2.0(footable.min.js+footable.sort.min.js+footable.paginate.min.js)"></script>
+  <script src="//cdn.jsdelivr.net/g/momentjs@2.14,lodash@4.15,angular.moment@0.10,masonry@4.1"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/angular-loading-bar/0.8.0/loading-bar.min.js"></script>
+  <!--<script src="/app/assets/js/loading-bar.min.js"></script>-->
   <script src="/app/assets/js/jquery.flot.orderBars.js"></script>
-  <script src="/app/assets/js/angular-masonry.min.js"></script>
-  <script src="/app/assets/js/angular-google-analytics.min.js"></script>
+  <!--<script src="/app/assets/js/angular-masonry.min.js"></script>-->
+  <script src="//cdn.jsdelivr.net/angular.masonry-packed/0.14.5/angular-masonry-packed.min.js"></script>
+  <!--<script src="/app/assets/js/angular-google-analytics.min.js"></script>-->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/angular-google-analytics/1.1.7/angular-google-analytics.min.js"></script>
+  <!-- if needed, include the charts using jsdelivr. Remove local version. -->
+  <!--<script src="//cdn.jsdelivr.net/angular.charts/0.2.7/angular-charts.min.js"></script>-->
   <script src="/app/assets/js/app.js?v=1.0.4"></script>
   <script src="/app/assets/js/services.js?v=1.0.4"></script>
   <script src="/app/assets/js/controllers.js?v=1.0.4"></script>

--- a/src/main/resources/app/index.html
+++ b/src/main/resources/app/index.html
@@ -3,31 +3,37 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>Budget App</title>
-  <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">
-  <link href="//cdn.jsdelivr.net/bootstrap/3.3/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="//cdn.jsdelivr.net/fontawesome/4.6/css/font-awesome.min.css" rel="stylesheet" />
-  <!--TODO move to jsdeliv-->
-  <link href="/app/assets/css/ionicons.min.css" rel="stylesheet" />
-  <link href="/app/assets/css/footable.core.min.css" rel="stylesheet" />
-  <link href="/app/assets/css/loading-bar.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/bootstrap/3.3/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/fontawesome/4.6/css/font-awesome.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/ionicons/2.0.1/css/ionicons.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/jquery.footable/2.0.3/css/footable.core.min.css" rel="stylesheet" />
+
+  <!-- not available on JSDelivr so using Cloudflare -->
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/angular-loading-bar/0.9.0/loading-bar.min.css" rel="stylesheet" />
+  <!-- end Cloudflare -->
+
+  <!-- local stylesheets, not available on jsdelivr -->
   <link href="/app/assets/css/style.css" rel="stylesheet" />
 
-  <script src="//cdn.jsdelivr.net/g/jquery@2.1"></script>
-  <!--<script src="//cdn.jsdelivr.net/g/angularjs@1.5(angular.min.js+angular-cookies.min.js+angular-resource.min.js+angular-route.min.js+angular-animate.min.js)"></script>-->
-  <script src="//cdn.jsdelivr.net/g/angularjs@1.4(angular.js+angular-cookies.js+angular-resource.js+angular-route.js+angular-animate.js)"></script>
-  <script src="//cdn.jsdelivr.net/g/angular.bootstrap@2.1(ui-bootstrap-tpls.min.js)"></script>
-  <script src="//cdn.jsdelivr.net/g/jquery.flot@0.8(jquery.flot.min.js+jquery.flot.categories.min.js+jquery.flot.time.js+jquery.flot.resize.js+jquery.flot.pie.js)"></script>
-  <script src="//cdn.jsdelivr.net/g/jquery.footable@2.0(footable.min.js+footable.sort.min.js+footable.paginate.min.js)"></script>
-  <script src="//cdn.jsdelivr.net/g/momentjs@2.14,lodash@4.15,angular.moment@0.10,masonry@4.1"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/angular-loading-bar/0.8.0/loading-bar.min.js"></script>
-  <!--<script src="/app/assets/js/loading-bar.min.js"></script>-->
+  <script src="https://cdn.jsdelivr.net/g/jquery@2.1"></script>
+  <script src="https://cdn.jsdelivr.net/g/angularjs@1.5(angular.js+angular-cookies.js+angular-resource.js+angular-route.js+angular-animate.js)"></script>
+  <script src="https://cdn.jsdelivr.net/g/angular.bootstrap@0.13.3(ui-bootstrap-tpls.min.js)"></script>
+  <script src="https://cdn.jsdelivr.net/g/jquery.flot@0.8(jquery.flot.min.js+jquery.flot.categories.min.js+jquery.flot.time.js+jquery.flot.resize.js+jquery.flot.pie.js)"></script>
+  <script src="https://cdn.jsdelivr.net/g/jquery.footable@2.0(footable.min.js+footable.sort.min.js+footable.paginate.min.js)"></script>
+  <script src="https://cdn.jsdelivr.net/g/momentjs@2.14,lodash@4.15,angular.moment@0.10,masonry@4.1"></script>
+
+  <!-- not available on JSDelivr so using Cloudflare -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.5/moment-timezone-with-data.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-loading-bar/0.9.0/loading-bar.min.js"></script>
+  <!-- end Cloudflare -->
+
   <script src="/app/assets/js/jquery.flot.orderBars.js"></script>
-  <!--<script src="/app/assets/js/angular-masonry.min.js"></script>-->
-  <script src="//cdn.jsdelivr.net/angular.masonry-packed/0.14.5/angular-masonry-packed.min.js"></script>
-  <!--<script src="/app/assets/js/angular-google-analytics.min.js"></script>-->
-  <script src="//cdnjs.cloudflare.com/ajax/libs/angular-google-analytics/1.1.7/angular-google-analytics.min.js"></script>
+
+  <script src="https://cdn.jsdelivr.net/angular.masonry-packed/0.14.5/angular-masonry-packed.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-google-analytics/1.1.7/angular-google-analytics.min.js"></script>
   <!-- if needed, include the charts using jsdelivr. Remove local version. -->
-  <!--<script src="//cdn.jsdelivr.net/angular.charts/0.2.7/angular-charts.min.js"></script>-->
+  <!--<script src="https://cdn.jsdelivr.net/angular.charts/0.2.7/angular-charts.min.js"></script>-->
   <script src="/app/assets/js/app.js?v=1.0.4"></script>
   <script src="/app/assets/js/services.js?v=1.0.4"></script>
   <script src="/app/assets/js/controllers.js?v=1.0.4"></script>


### PR DESCRIPTION
I looked at the problem related to the blank page on Safari (Mac). It seems to be a combination of:

1. Google Analytics being blocked (it is needed for instantiating the app) 
2. Downloading of the single large JS from JSDelivr

I don't know if (2) is itself a problem, but I found it difficult to read the versions of the libraries and, if required, upgrade them when fixes are released. So, I split the line into separate http requests. Since the browser will cache the downloads, I am hoping the performance impact will not be large and will be one time. Makes it more readable for me.

I also made the Analytics instantiation optional ( using hint from http://stackoverflow.com/questions/18542032/optional-dependencies-in-angularjs ), and then realized the Account ID was also hardcoded, so pulled it out into a property. I would love to make it a maven based property so that my private deployment of budgetapp would go to my Google Analytics account, but that may be wishful thinking at this time and a fix for another day.
