### PR TITLE
Add API endpoint to add multiple transactions

### DIFF
--- a/src/main/java/io/budgetapp/dao/BudgetDAO.java
+++ b/src/main/java/io/budgetapp/dao/BudgetDAO.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -93,6 +94,18 @@ public class BudgetDAO extends AbstractDAO<Budget> {
     }
 
     /**
+     * Throws an error if the budget does not belong to the user
+     * @param user
+     * @param budget
+     * @throws AccessDeniedException
+     */
+    private void checkBudget(User user, Budget budget) throws AccessDeniedException {
+        if(!Objects.equals(user.getId(), budget.getUser().getId())) {
+            throw new AccessDeniedException();
+        }
+    }
+
+    /**
      * find budget by given id
      * @param budgetId
      * @return
@@ -114,10 +127,33 @@ public class BudgetDAO extends AbstractDAO<Budget> {
      */
     public Budget findById(User user, Long budgetId) {
         Budget budget = findById(budgetId);
-        if(!Objects.equals(user.getId(), budget.getUser().getId())) {
-            throw new AccessDeniedException();
-        }
+        checkBudget(user, budget);
         return budget;
+    }
+
+    /**
+     * find all budgets for given ids
+     * @param budgetIds
+     * @return
+     */
+    public List<Budget> findByIds(Collection<Long> budgetIds) {
+        Criteria criteria = criteria();
+        criteria.add(Restrictions.in("id", budgetIds));
+        return list(criteria);
+    }
+
+    /**
+     * find all budgets for given user and ids
+     * @param user
+     * @param budgetIds
+     * @return
+     */
+    public List<Budget> findByIds(User user, Collection<Long> budgetIds) {
+        List<Budget> budgets = findByIds(budgetIds);
+        for (Budget budget : budgets) {
+            checkBudget(user, budget);
+        }
+        return budgets;
     }
 
     public void update(Budget budget) {

--- a/src/main/java/io/budgetapp/dao/TransactionDAO.java
+++ b/src/main/java/io/budgetapp/dao/TransactionDAO.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -31,6 +32,13 @@ public class TransactionDAO extends AbstractDAO<Transaction> {
     public Transaction addTransaction(Transaction transaction) {
         LOGGER.debug("Add transaction {}", transaction);
         return persist(transaction);
+    }
+
+    public List<Transaction> addTransactions(List<Transaction> transactions) {
+        return transactions
+                .stream()
+                .map(this::addTransaction)
+                .collect(Collectors.toList());
     }
 
     public List<Transaction> find(User user, Integer limit) {

--- a/src/main/java/io/budgetapp/resource/BudgetResource.java
+++ b/src/main/java/io/budgetapp/resource/BudgetResource.java
@@ -48,6 +48,13 @@ public class BudgetResource extends AbstractResource {
         return financeService.findBudgetsByUser(user);
     }
 
+    @GET
+    @UnitOfWork
+    @Path("/{month}/{year}")
+    public List<Budget> getBudgets(@Auth User user, @PathParam("month") int month, @PathParam("year") int year) {
+        return financeService.findBudgetByUser(user, month, year);
+    }
+
     @POST
     @UnitOfWork
     public Response add(@Auth User user, @Valid AddBudgetForm budgetForm) {

--- a/src/main/java/io/budgetapp/resource/TransactionResource.java
+++ b/src/main/java/io/budgetapp/resource/TransactionResource.java
@@ -12,6 +12,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -43,6 +44,17 @@ public class TransactionResource extends AbstractResource {
     public Response add(@Auth User user, TransactionForm transactionForm) {
         Transaction transaction = financeService.addTransaction(user, transactionForm);
         return created(transaction, transaction.getId());
+    }
+
+    @POST
+    @UnitOfWork
+    @Path("/batched")
+    public List<Response> add(@Auth User user, List<TransactionForm> transactionForms) {
+        List<Transaction> transactions = financeService.addTransactions(user, transactionForms);
+        return transactions
+                .stream()
+                .map(transaction -> created(transaction, transaction.getId()))
+                .collect(Collectors.toList());
     }
 
     @GET

--- a/src/main/java/io/budgetapp/service/FinanceService.java
+++ b/src/main/java/io/budgetapp/service/FinanceService.java
@@ -1,6 +1,8 @@
 package io.budgetapp.service;
 
+import com.google.common.collect.ImmutableList;
 import io.budgetapp.application.DataConstraintException;
+import io.budgetapp.application.NotFoundException;
 import io.budgetapp.crypto.PasswordEncoder;
 import io.budgetapp.dao.AuthTokenDAO;
 import io.budgetapp.dao.CategoryDAO;
@@ -32,7 +34,6 @@ import io.budgetapp.model.form.report.SearchFilter;
 import io.budgetapp.model.form.user.Password;
 import io.budgetapp.model.form.user.Profile;
 import io.budgetapp.util.Util;
-import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -415,51 +416,77 @@ public class FinanceService {
     // TRANSACTION
     //==================================================================
     public Transaction addTransaction(User user, TransactionForm transactionForm) {
+        return addTransactions(user, ImmutableList.of(transactionForm)).get(0);
+    }
 
-        Budget budget = budgetDAO.findById(user, transactionForm.getBudget().getId());
+    public List<Transaction> addTransactions(User user, List<TransactionForm> transactionForms) {
+        Set<Long> budgetIds = transactionForms
+                .stream()
+                .map(TransactionForm::getBudget)
+                .map(Budget::getId)
+                .collect(Collectors.toSet());
+
+        List<Budget> budgets = budgetDAO.findByIds(user, budgetIds);
+
+        Map<Long, Budget> budgetMap = new HashMap<>();
+
+        for (Budget budget : budgets) {
+            budgetMap.put(budget.getId(), budget);
+        }
+
+        List<Transaction> transactions = new ArrayList<>();
 
         // validation
-        if(transactionForm.getAmount() == 0) {
-            throw new DataConstraintException("amount", "Amount is required");
+        for (TransactionForm transactionForm : transactionForms) {
+
+            Budget budget = budgetMap.get(transactionForm.getBudget().getId());
+            if (budget == null) {
+                throw new NotFoundException();
+            }
+
+            if (transactionForm.getAmount() == 0) {
+                throw new DataConstraintException("amount", "Amount is required");
+            }
+
+            if (Boolean.TRUE.equals(transactionForm.getRecurring()) && transactionForm.getRecurringType() == null) {
+                throw new DataConstraintException("recurringType", "Recurring Type is required");
+            }
+
+            Date transactionOn = transactionForm.getTransactionOn();
+            if (!Util.inMonth(transactionOn, budget.getPeriod())) {
+                throw new DataConstraintException("transactionOn", "Transaction Date must within " + Util.toFriendlyMonthDisplay(budget.getPeriod()) + " " + (budget.getPeriod().getYear() + 1900));
+            }
+            // end validation
+
+            budget.setActual(budget.getActual() + transactionForm.getAmount());
+            budgetDAO.update(budget);
+
+            Recurring recurring = new Recurring();
+            if (Boolean.TRUE.equals(transactionForm.getRecurring())) {
+                LOGGER.debug("Add recurring {} by {}", transactionForm, user);
+                recurring.setAmount(transactionForm.getAmount());
+                recurring.setRecurringType(transactionForm.getRecurringType());
+                recurring.setBudgetType(budget.getBudgetType());
+                recurring.setRemark(transactionForm.getRemark());
+                recurring.setLastRunAt(transactionForm.getTransactionOn());
+                recurringDAO.addRecurring(recurring);
+            }
+
+            Transaction transaction = new Transaction();
+            transaction.setName(budget.getName());
+            transaction.setAmount(transactionForm.getAmount());
+            transaction.setRemark(transactionForm.getRemark());
+            transaction.setAuto(Boolean.TRUE.equals(transactionForm.getRecurring()));
+            transaction.setTransactionOn(transactionForm.getTransactionOn());
+            transaction.setBudget(transactionForm.getBudget());
+            if (Boolean.TRUE.equals(transactionForm.getRecurring())) {
+                transaction.setRecurring(recurring);
+            }
+
+            transactions.add(transaction);
         }
 
-        if(Boolean.TRUE.equals(transactionForm.getRecurring()) && transactionForm.getRecurringType() == null) {
-            throw new DataConstraintException("recurringType", "Recurring Type is required");
-        }
-
-        Date transactionOn = transactionForm.getTransactionOn();
-        if(!Util.inMonth(transactionOn, budget.getPeriod())) {
-            throw new DataConstraintException("transactionOn", "Transaction Date must within " + Util.toFriendlyMonthDisplay(budget.getPeriod()) + " " + (budget.getPeriod().getYear() + 1900));
-        }
-        // end validation
-
-
-        budget.setActual(budget.getActual() + transactionForm.getAmount());
-        budgetDAO.update(budget);
-
-        Recurring recurring = new Recurring();
-        if(Boolean.TRUE.equals(transactionForm.getRecurring())) {
-            LOGGER.debug("Add recurring {} by {}", transactionForm, user);
-            recurring.setAmount(transactionForm.getAmount());
-            recurring.setRecurringType(transactionForm.getRecurringType());
-            recurring.setBudgetType(budget.getBudgetType());
-            recurring.setRemark(transactionForm.getRemark());
-            recurring.setLastRunAt(transactionForm.getTransactionOn());
-            recurringDAO.addRecurring(recurring);
-        }
-
-        Transaction transaction = new Transaction();
-        transaction.setName(budget.getName());
-        transaction.setAmount(transactionForm.getAmount());
-        transaction.setRemark(transactionForm.getRemark());
-        transaction.setAuto(Boolean.TRUE.equals(transactionForm.getRecurring()));
-        transaction.setTransactionOn(transactionForm.getTransactionOn());
-        transaction.setBudget(transactionForm.getBudget());
-        if(Boolean.TRUE.equals(transactionForm.getRecurring())) {
-            transaction.setRecurring(recurring);
-        }
-
-        return transactionDAO.addTransaction(transaction);
+        return transactionDAO.addTransactions(transactions);
     }
 
     public boolean deleteTransaction(User user, long transactionId) {

--- a/src/main/java/io/budgetapp/service/FinanceService.java
+++ b/src/main/java/io/budgetapp/service/FinanceService.java
@@ -144,21 +144,10 @@ public class FinanceService {
 
 
     public AccountSummary findAccountSummaryByUser(User user, Integer month, Integer year) {
-        if(month == null || year == null) {
-            LocalDate now = LocalDate.now();
-            month = now.getMonthValue();
-            year = now.getYear();
-        }
+        List<Budget> budgets = findBudgetByUser(user, month, year);
+
         LOGGER.debug("Find account summary {} {}-{}", user, month, year);
         AccountSummary accountSummary = new AccountSummary();
-        List<Budget> budgets = budgetDAO.findBudgets(user, month, year, true);
-
-        // no budgets, first time access
-        if(budgets.isEmpty()) {
-            LOGGER.debug("First time access budgets {} {}-{}", user, month, year);
-            initCategoriesAndBudgets(user, month, year);
-            budgets = budgetDAO.findBudgets(user, month, year, true);
-        }
         Map<Category, List<Budget>> grouped = budgets
                 .stream()
                 .collect(Collectors.groupingBy(Budget::getCategory));
@@ -276,6 +265,27 @@ public class FinanceService {
 
     public List<Budget> findBudgetsByUser(User user) {
         return budgetDAO.findBudgets(user);
+    }
+
+    public List<Budget> findBudgetByUser(User user, Integer month, Integer year) {
+        LOGGER.debug("Find budget for user {} {}-{}", user, month, year);
+
+        if(month == null || year == null) {
+            LocalDate now = LocalDate.now();
+            month = now.getMonthValue();
+            year = now.getYear();
+        }
+
+        List<Budget> budgets = budgetDAO.findBudgets(user, month, year, false);
+
+        // no budgets, first time access
+        if(budgets.isEmpty()) {
+            LOGGER.debug("First time access budgets {} {}-{}", user, month, year);
+            initCategoriesAndBudgets(user, month, year);
+            budgets = budgetDAO.findBudgets(user, month, year, false);
+        }
+
+        return budgets;
     }
 
     public Budget findBudgetById(User user, long budgetId) {


### PR DESCRIPTION
### Biggest changes

- Added endpoint to POST List of transactionForm
- Added `FinanceService#addTransactions` 
   - Gets map of budgets for each budgetId
   - Loops through transactions and does same logic as was in `FinanceService#addTransaction` 
- `FinanceService#addTransaction` now just calls `FinanceService#addTransactions` with a list of length 1
- Expose ability to get budgets by month 